### PR TITLE
Manifest build sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Flipper Air Mouse
 
+[![FAP Factory](https://fap.playmean.xyz/api/v1/ginkage/FlippAirMouse/badge)](https://fap.playmean.xyz/ginkage/FlippAirMouse)
+
 ## Brief
 
 > "You can turn anything into an air mouse if you're brave enough"

--- a/application.fam
+++ b/application.fam
@@ -6,4 +6,5 @@ App(
     stack_size=10 * 1024,
     fap_category="Tools",
     icon="A_Plugins_14",
+    sources=["*.c", "*.cc"],
 )


### PR DESCRIPTION
Building with `ufbt` tool fails to `/schematic/airmouse_bom.csv: file format not recognized; treating as linker script` while linking. Specifying `sources=["*.c", "*.cc"]` helps with it.

Also there is a badge of service with automatic release builds, if you like ✌️