### PR TITLE
Added compatibility (?) for BNO055

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+dist/*
+.vscode
+.clang-format
+.clangd
+.editorconfig
+.env
+.ufbt

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/lsm6ds3tr-api"]
 	path = lib/lsm6ds3tr-api
 	url = https://github.com/STMicroelectronics/lsm6ds3tr-c-pid.git
+[submodule "lib/BNO055_SensorAPI"]
+	path = lib/BNO055_SensorAPI
+	url = https://github.com/boschsensortec/BNO055_SensorAPI.git

--- a/air_mouse.c
+++ b/air_mouse.c
@@ -58,7 +58,6 @@ AirMouse* air_mouse_app_alloc() {
 
     // Gui
     app->gui = furi_record_open(RECORD_GUI);
-
     // View dispatcher
     app->view_dispatcher = view_dispatcher_alloc();
     view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
@@ -98,7 +97,8 @@ AirMouse* air_mouse_app_alloc() {
 
     app->error_dialog = dialog_ex_alloc();
     dialog_ex_set_header(app->error_dialog, "Failed to init IMU", 63, 0, AlignCenter, AlignTop);
-    dialog_ex_set_text(app->error_dialog, "Please connect sensor module", 63, 30, AlignCenter, AlignTop);
+    dialog_ex_set_text(
+        app->error_dialog, "Please connect sensor module", 63, 30, AlignCenter, AlignTop);
     view_set_previous_callback(dialog_ex_get_view(app->error_dialog), air_mouse_exit);
     view_dispatcher_add_view(
         app->view_dispatcher, AirMouseViewError, dialog_ex_get_view(app->error_dialog));

--- a/application.fam
+++ b/application.fam
@@ -1,6 +1,6 @@
 App(
     appid="air_mouse",
-    name="BMI Air Mouse",
+    name="BMI Air Mouse (New)",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="air_mouse_app",
     stack_size=10 * 1024,
@@ -27,5 +27,6 @@ App(
             name="lsm6dso-api",
             cflags=["-Wno-error"],
         ),
+        Lib(name="BNO055_SensorAPI", cflags=["-Wno-error"]),
     ],
 )

--- a/application.fam
+++ b/application.fam
@@ -27,5 +27,6 @@ App(
             name="lsm6dso-api",
             cflags=["-Wno-error"],
         ),
+        Lib(name="BNO055_SensorAPI", cflags=["-Wno-error"]),
     ],
 )

--- a/tracking/imu/bno055.c
+++ b/tracking/imu/bno055.c
@@ -1,0 +1,80 @@
+#include "imu.h"
+#include "../../lib/BNO055_SensorAPI/bno055.h"
+
+#define BNO055_TAG      "BNO055"
+#define BNO055_DEV_ADDR (BNO055_I2C_ADDR1 << 1)
+
+struct bno055_t bno055dev;
+struct bno055_accel_t bno055_accel;
+struct bno055_gyro_t bno055_gyro;
+
+int8_t bno055_i2c_bus_write(uint8_t dev_addr, uint8_t reg_addr, uint8_t* reg_data, uint8_t cnt) {
+    if(furi_hal_i2c_write_mem(&furi_hal_i2c_handle_external, dev_addr, reg_addr, reg_data, cnt, 50))
+        return BNO055_SUCCESS;
+    return BNO055_ERROR;
+}
+
+int8_t bno055_i2c_bus_read(uint8_t dev_addr, uint8_t reg_addr, uint8_t* reg_data, uint8_t cnt) {
+    if(furi_hal_i2c_read_mem(&furi_hal_i2c_handle_external, dev_addr, reg_addr, reg_data, cnt, 50))
+        return BNO055_SUCCESS;
+    return BNO055_ERROR;
+}
+
+void bno055_delay_msec(u32 msec) {
+    furi_delay_ms(msec);
+}
+
+bool bno055_begin() {
+    FURI_LOG_I(BNO055_TAG, "Init BNO055");
+
+    if(!furi_hal_i2c_is_device_ready(&furi_hal_i2c_handle_external, BNO055_DEV_ADDR, 50)) {
+        FURI_LOG_E(BNO055_TAG, "Not ready");
+        return false;
+    }
+
+    bno055dev.bus_write = bno055_i2c_bus_write;
+    bno055dev.bus_read = bno055_i2c_bus_read;
+    bno055dev.delay_msec = bno055_delay_msec;
+    bno055dev.dev_addr = BNO055_DEV_ADDR;
+
+    if(bno055_init(&bno055dev) != BNO055_SUCCESS) {
+        FURI_LOG_E(BNO055_TAG, "Init failed");
+        return false;
+    }
+
+    if(bno055_set_power_mode(BNO055_POWER_MODE_NORMAL) != BNO055_SUCCESS) {
+        FURI_LOG_E(BNO055_TAG, "Power mode set failed");
+        return false;
+    }
+
+    if(bno055_set_operation_mode(BNO055_OPERATION_MODE_NDOF) != BNO055_SUCCESS) {
+        FURI_LOG_E(BNO055_TAG, "Operation mode set failed");
+        return false;
+    }
+
+    FURI_LOG_I(BNO055_TAG, "Init OK");
+    return true;
+}
+
+void bno055_end() {
+    bno055_set_power_mode(BNO055_POWER_MODE_SUSPEND);
+}
+
+int bno055_read(double* vec) {
+    int ret = 0;
+    if(bno055_read_accel_xyz(&bno055_accel) == BNO055_SUCCESS) {
+        vec[0] = bno055_accel.x / 100.0; // m/s^2
+        vec[1] = bno055_accel.y / 100.0;
+        vec[2] = bno055_accel.z / 100.0;
+        ret |= ACC_DATA_READY;
+    }
+    if(bno055_read_gyro_xyz(&bno055_gyro) == BNO055_SUCCESS) {
+        vec[3] = bno055_gyro.x * (float)DEG_TO_RAD / 16.0; // rad/s
+        vec[4] = bno055_gyro.y * (float)DEG_TO_RAD / 16.0;
+        vec[5] = bno055_gyro.z * (float)DEG_TO_RAD / 16.0;
+        ret |= GYR_DATA_READY;
+    }
+    return ret;
+}
+
+struct imu_t imu_bno055 = {BNO055_DEV_ADDR, bno055_begin, bno055_end, bno055_read, BNO055_TAG};

--- a/tracking/imu/imu.c
+++ b/tracking/imu/imu.c
@@ -5,12 +5,9 @@
 extern struct imu_t imu_bmi160;
 extern struct imu_t imu_lsm6ds3trc;
 extern struct imu_t imu_lsm6dso;
+extern struct imu_t imu_bno055;
 
-struct imu_t* imu_types[] = {
-    &imu_bmi160,
-    &imu_lsm6ds3trc,
-    &imu_lsm6dso
-};
+struct imu_t* imu_types[] = {&imu_bmi160, &imu_lsm6ds3trc, &imu_lsm6dso, &imu_bno055};
 
 static const int imu_count = sizeof(imu_types) / sizeof(struct imu_t*);
 
@@ -19,6 +16,7 @@ static struct imu_t* imu_found;
 struct imu_t* find_imu() {
     unsigned int i;
     for(i = 0; i < imu_count; i++) {
+        FURI_LOG_D(IMU_TAG, "Scanning");
         if(furi_hal_i2c_is_device_ready(&furi_hal_i2c_handle_external, imu_types[i]->address, 50)) {
             FURI_LOG_E(IMU_TAG, "found i2c device address 0x%X", imu_types[i]->address);
             return imu_types[i];
@@ -31,30 +29,26 @@ bool imu_begin() {
     bool ret = false;
     furi_hal_i2c_acquire(&furi_hal_i2c_handle_external);
 
-    if (imu_found == NULL) {
+    if(imu_found == NULL) {
         imu_found = find_imu();
-        if (imu_found != NULL)
-            FURI_LOG_E(IMU_TAG, "Found Device %s", imu_found->name);
+        if(imu_found != NULL) FURI_LOG_E(IMU_TAG, "Found Device %s", imu_found->name);
     }
 
-    if (imu_found != NULL)
-        ret = imu_found->begin();
+    if(imu_found != NULL) ret = imu_found->begin();
 
     furi_hal_i2c_release(&furi_hal_i2c_handle_external);
     return ret;
 }
 
 void imu_end() {
-    if (imu_found == NULL)
-        return;
+    if(imu_found == NULL) return;
     furi_hal_i2c_acquire(&furi_hal_i2c_handle_external);
     imu_found->end();
     furi_hal_i2c_release(&furi_hal_i2c_handle_external);
 }
 
 int imu_read(double* vec) {
-    if (imu_found == NULL)
-        return 0;
+    if(imu_found == NULL) return 0;
     furi_hal_i2c_acquire(&furi_hal_i2c_handle_external);
     int ret = imu_found->read(vec);
     furi_hal_i2c_release(&furi_hal_i2c_handle_external);


### PR DESCRIPTION
## What happened
- I grabbed Bosh's driver for the BNO055 and implemented it in the /tracking/imu folder following the other style the other IMUs had. 
- I connected everything and it doesn't work 
  - Turns out, my BNO055 was dead on arrival (what I get for cheaping out on the IMU). Did a I2C scan with a ESP32 and while other devices showed up, the 055 did not show up. 
- Due to the above reason, I have not been able to test the code, so this is more of a note/heads up to people who might have a BNO055 lying around and want to test the code. I will order one as soon as I can to test with.
- Note: The file does compile and does upload. I just get stuck on the no I2C device found page...
- Note: Unsure whether the address is `0x28` or `0x29` by default.

## Questions for the maintainer
- Did I write the implementation correctly (I surely hope so). I read the implementations for all of the IMUs that are in the supported list and followed what they were doing as closely as possible. However, there may be some errors here and there. (but it compiles)

## What I did
- Added implementation for BNO055 sensor
- Added .gitignore to ignore build files
- Made a dist folder (because the ufbt tool seems to do that automatically and didn't ignroe the folder)

### Disclaimer
- Please excuse the sub optimal code. I am still quite new to writing code for the flipper, so I do not know best practices yet.
- This functionality has not yet been tested to be working and is a work in progress. Please merge when it is complete.